### PR TITLE
Add upcoming courses list

### DIFF
--- a/src/components/CourseList/CourseList.module.css
+++ b/src/components/CourseList/CourseList.module.css
@@ -1,5 +1,7 @@
 .courseList {
   list-style: none;
+  padding-top: 1rem;
+  border-top: 1px solid var(--gym-gray);
 }
 
 .courseContainer figcaption {

--- a/src/components/CourseList/CourseSummaryListItem.js
+++ b/src/components/CourseList/CourseSummaryListItem.js
@@ -17,7 +17,6 @@ const CourseSummaryListItem = ({ course }) => {
     skillsCovered,
     thisCourseIsFor,
   } = course;
-  console.dir('course is', course);
 
   const courseAboutUrl = `${CONSTANTS.URLS.COURSES.LIST}${courseNumber}/about`;
 

--- a/src/components/Microcopy/Microcopy.js
+++ b/src/components/Microcopy/Microcopy.js
@@ -21,7 +21,7 @@ export const getMicrocopy = (title, microcopyDictionary) => {
   return foundCopy.bodyHtml;
 };
 
-const Microcopy = ({ component: Component = 'div', title, data }) => {
+const Microcopy = ({ component: Component = 'div', title, data, ...rest }) => {
   return (
     <StaticQuery
       query={graphql`
@@ -39,7 +39,12 @@ const Microcopy = ({ component: Component = 'div', title, data }) => {
       render={data => {
         const { microcopyDictionary } = data.takeshape;
         const microcopy = getMicrocopy(title, microcopyDictionary.items);
-        return <Component dangerouslySetInnerHTML={{ __html: microcopy }} />;
+        return (
+          <Component
+            dangerouslySetInnerHTML={{ __html: microcopy }}
+            {...rest}
+          />
+        );
       }}
     />
   );

--- a/src/components/UpcomingCoursesList/UpcomingCourse.js
+++ b/src/components/UpcomingCoursesList/UpcomingCourse.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import classes from './UpcomingCourse.module.css';
+
+const UpcomingCourse = ({ course }) => {
+  if (!course) return null;
+
+  return (
+    <section className={classes.upcomingCourseContainer}>
+      {course.title && <h3>{course.title}</h3>}
+
+      {course.shortDescription && <p>{course.shortDescription}</p>}
+    </section>
+  );
+};
+
+UpcomingCourse.propTypes = {
+  course: PropTypes.shape({
+    title: PropTypes.string,
+    shortDescription: PropTypes.string,
+  }),
+};
+
+export default UpcomingCourse;

--- a/src/components/UpcomingCoursesList/UpcomingCourse.module.css
+++ b/src/components/UpcomingCoursesList/UpcomingCourse.module.css
@@ -1,0 +1,8 @@
+h2.listTitle {
+  font-size: 1.5rem;
+}
+
+.upcomingCourseContainer {
+  border-top: 1px solid var(--gym-gray);
+  padding-top: 1rem;
+}

--- a/src/components/UpcomingCoursesList/UpcomingCoursesList.js
+++ b/src/components/UpcomingCoursesList/UpcomingCoursesList.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StaticQuery, graphql } from 'gatsby';
+
+import { UpcomingCourse } from '.';
+
+const UpcomingCoursesList = props => {
+  const { courses } = props.data.takeshape;
+
+  return (
+    <React.Fragment>
+      <h2>Upcoming Courses</h2>
+      {courses.items.map(course => (
+        <UpcomingCourse course={course} key={course._id} />
+      ))}
+    </React.Fragment>
+  );
+};
+
+UpcomingCoursesList.propTypes = {
+  data: PropTypes.shape({
+    takeshape: PropTypes.shape({
+      courses: PropTypes.shape({
+        items: PropTypes.arrayOf(
+          PropTypes.shape({
+            title: PropTypes.string,
+            shortDescription: PropTypes.string,
+          })
+        ),
+      }),
+    }),
+  }),
+};
+
+export const query = graphql`
+  {
+    takeshape {
+      courses: getUpcomingCourseList {
+        items {
+          title
+          shortDescription
+          _id
+        }
+      }
+    }
+  }
+`;
+
+export default props => (
+  <StaticQuery
+    query={query}
+    render={data => <UpcomingCoursesList data={data} {...props} />}
+  />
+);

--- a/src/components/UpcomingCoursesList/index.js
+++ b/src/components/UpcomingCoursesList/index.js
@@ -1,0 +1,2 @@
+export { default as UpcomingCoursesList } from './UpcomingCoursesList';
+export { default as UpcomingCourse } from './UpcomingCourse';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,3 +9,4 @@ export { Link } from './Link';
 export { Layout } from './Layout';
 export { Microcopy } from './Microcopy';
 export { SEO } from './Seo';
+export { UpcomingCoursesList } from './UpcomingCoursesList';

--- a/src/pages/courses/Courses.module.css
+++ b/src/pages/courses/Courses.module.css
@@ -2,16 +2,58 @@
   background-color: var(--gym-light-page-background);
 }
 
-.courseListContainer {
+.pageContentContainer {
   background-color: var(--gym-white);
-  padding: 1rem 1.5rem;
+  padding: 0 2rem;
 }
 
-.courseListContainer h1,
-.courseListContainer h2 {
+.pageContentContainer h1,
+.pageContentContainer h2,
+.pageContentContainer h3 {
   font-family: var(--gym-font-stack);
   font-weight: 900;
-  font-size: 30px;
   text-transform: uppercase;
   margin-bottom: 1rem;
+}
+
+.pageContentContainer h2 {
+  font-size: 20px;
+}
+
+.pageContentContainer h3 {
+  font-size: 15px;
+}
+
+.courseListColumn,
+.rightHandColumn {
+  padding-top: 1rem;
+}
+
+.courseListColumn {
+  border-right: 1px dashed var(--gym-gray);
+}
+
+nav.subnav {
+  padding: 1rem 0;
+}
+
+nav.subnav a {
+  margin-right: 1rem;
+  text-transform: uppercase;
+  color: var(--gym-black);
+  font-weight: bold;
+  font-family: var(--gym-font-stack);
+  font-size: 1.1rem;
+}
+
+nav.subnav a:hover {
+  color: var(--gym-orange);
+  text-decoration: none;
+  border-bottom: 1px solid;
+}
+
+.courseTypeDescription {
+  font-family: var(--gym-font-stack);
+  font-weight: 300;
+  font-size: 22px;
 }

--- a/src/pages/courses/index.js
+++ b/src/pages/courses/index.js
@@ -2,7 +2,12 @@ import React from 'react';
 import { graphql } from 'gatsby';
 
 import { Container, Col, Row } from 'react-bootstrap';
-import { CourseList, Layout, Microcopy } from '../../components';
+import {
+  CourseList,
+  Layout,
+  Microcopy,
+  UpcomingCoursesList,
+} from '../../components';
 
 import classes from './Courses.module.css';
 
@@ -13,34 +18,46 @@ const CoursesPage = ({ data }) => {
     <Layout>
       <div className={classes.pageContainer}>
         <Container>
-          <nav>
+          <nav className={classes.subnav}>
             <a href="#full-courses">Full Courses</a>
             <a href="#gym-shorts">Gym Shorts</a>
             <a href="#take-5">Take 5</a>
           </nav>
         </Container>
         <Container>
-          <Row>
-            <Col>
-              <div className={classes.courseListContainer}>
+          <div className={classes.pageContentContainer}>
+            <Row>
+              <Col className={classes.courseListColumn}>
                 <section>
                   <h1 id="full-courses">Full Courses</h1>
-                  <Microcopy title="full-courses-description" />
+                  <Microcopy
+                    title="full-courses-description"
+                    className={classes.courseTypeDescription}
+                  />
                   <CourseList courses={fullCourses.items} />
                 </section>
                 <section>
                   <h1 id="gym-shorts">Gym Shorts</h1>
-                  <Microcopy title="full-courses-description" />
+                  <Microcopy
+                    title="full-courses-description"
+                    className={classes.courseTypeDescription}
+                  />
                   <CourseList />
                 </section>
                 <section>
                   <h1 id="take-5">Take 5</h1>
-                  <Microcopy title="take-five-description" />
+                  <Microcopy
+                    title="take-five-description"
+                    className={classes.courseTypeDescription}
+                  />
                   <CourseList />
                 </section>
-              </div>
-            </Col>
-          </Row>
+              </Col>
+              <Col md={3} className={classes.rightHandColumn}>
+                <UpcomingCoursesList />
+              </Col>
+            </Row>
+          </div>
         </Container>
       </div>
     </Layout>


### PR DESCRIPTION
# What's in this PR?
The `/courses` page is nearly done! I believe all that's left is populating it with content.

In the future, the upcoming courses list will be managed from the [Upcoming Course](https://app.takeshape.io/projects/4d48bc9b-1e58-46b8-ac37-71f84218510e/content/upcomingCourse) content type in takeshape.

# To test
1. pull down this branch
1. run `yarn` to install dependencies
1. run `yarn start` to fire it up
1. check out [localhost:8000/courses](http://localhost:8000/courses), look at the beautiful layout:

![image](https://user-images.githubusercontent.com/1844496/58503992-b88e9280-8157-11e9-8319-3fa1d3b359f2.png)
