### PR TITLE
market dropdown presentation changes

### DIFF
--- a/src/components/Jobs/MarketDropdown.css
+++ b/src/components/Jobs/MarketDropdown.css
@@ -1,6 +1,7 @@
 [data-reach-listbox-popover] {
   max-height: 60vh;
   overflow-y: scroll;
+  z-index: 1000;
 }
 
 [data-reach-listbox-input],

--- a/src/components/Jobs/MarketDropdown.js
+++ b/src/components/Jobs/MarketDropdown.js
@@ -3,22 +3,31 @@ import React from 'react';
 import { Listbox, ListboxOption } from '@reach/listbox';
 import '@reach/listbox/styles.css';
 
+import { Text } from '@chakra-ui/core';
+
 import './MarketDropdown.css';
 
 import { MARKETS } from '../../utils/constants';
 
-// render a ListboxOption for a single market
-const marketOption = market => {
-  return (
-    <ListboxOption value={market.id.toString()} key={market.id}>
-      {market.name}
-    </ListboxOption>
-  );
-};
-
 // take an array of markets, and render a ListboxOption for each of them
-const marketOptionList = markets => {
-  return markets.map(market => marketOption(market));
+const marketOptionList = (markets, title) => {
+  return (
+    <>
+      {title && (
+        <ListboxOption disabled value={`disabled--${title}`}>
+          <Text fontSize="larger" fontWeight="bold" textTransform="uppercase">
+            {title}
+          </Text>
+        </ListboxOption>
+      )}
+      {markets.map(market => (
+        <ListboxOption value={market.id.toString()} key={market.id}>
+          {market.name}
+        </ListboxOption>
+      ))}
+      <hr />
+    </>
+  );
 };
 
 const MarketDropdown = ({ onChange, value }) => {
@@ -28,13 +37,10 @@ const MarketDropdown = ({ onChange, value }) => {
       value={value.toString()}
       onChange={onChange}
     >
-      {marketOptionList(MARKETS.NORTH_AMERICAN_MARKETS)}
-      <hr />
-      {marketOptionList(MARKETS.EUROPEAN_MARKETS)}
-      <hr />
-      {marketOptionList(MARKETS.ASIAN_MARKETS)}
-      <hr />
-      {marketOptionList(MARKETS.AUSTRALIAN_MARKETS)}
+      {marketOptionList(MARKETS.NORTH_AMERICAN_MARKETS, 'North America')}
+      {marketOptionList(MARKETS.EUROPEAN_MARKETS, 'Europe')}
+      {marketOptionList(MARKETS.ASIAN_MARKETS, 'Asia')}
+      {marketOptionList(MARKETS.AUSTRALIAN_MARKETS, 'Australia')}
     </Listbox>
   );
 };


### PR DESCRIPTION
This PR contains updates to the Market Dropdown component, which organizes markets by their geographical location:
- north america
- europe
- asia
- australia

I also added a label to the dropdown for each of the above buckets 👍🏻